### PR TITLE
fix div tostring (?)

### DIFF
--- a/Source/Symbolic/Operations/Div.hpp
+++ b/Source/Symbolic/Operations/Div.hpp
@@ -59,7 +59,7 @@ namespace sym {
 
     template<Expression Lhs_, Expression Rhs_>
     auto toString(const Div<Lhs_, Rhs_> &x) -> std::string {
-        return "(" + sym::toString(x.lhs) + "/" + sym::toString(x.rhs) + ")";
+        return "(" + toString(x.lhs) + "/" + toString(x.rhs) + ")";
     }
 
     template<Expression Lhs_, Expression Rhs_>

--- a/Test/Symbolic/ToString.cpp
+++ b/Test/Symbolic/ToString.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "Symbolic/Operators.hpp"
 #include "Symbolic/Variable.hpp"
 
 TEST(ToString, String) {
@@ -37,4 +38,10 @@ TEST(ToString, AutomaticName) {
 
     EXPECT_NE(toString(v), toString(longName));
     EXPECT_FALSE((std::is_same_v<decltype(v), decltype(longName)>) );
+}
+
+TEST(ToString, DivideByRuntimeConstant) {
+    SYM_VARIABLE(a);
+    auto div = a / sym::RuntimeConstant(2.0);
+    EXPECT_EQ(toString(div), "(a/2.000000)");
 }


### PR DESCRIPTION
jo also ich weiß auch nicht warum aber das fixt den hinzugefügten toString test (compile)... in tests/div.cpp gibt es einen toString der mit passenden includes auch kompiliert, aber im carolo code hab ich nicht geschafft das mit include-order zu "fixen"